### PR TITLE
fix: depency bump for rich text fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-line-truncation",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "~9.1.7",
     "@angular/router": "~9.1.7",
     "core-js": "^3.1.4",
-    "line-truncation": "^1.2.5",
+    "line-truncation": "^1.3.9",
     "rxjs": "~6.5.5",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/projects/line-truncation-lib/package.json
+++ b/projects/line-truncation-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-line-truncation",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Ngx Line Truncation is line truncation implementation for Angular that truncate text by user defined line number.",
   "keywords": [
     "ellipsis",
@@ -25,6 +25,6 @@
     "@angular/core": "^9.0.0"
   },
   "dependencies": {
-    "line-truncation": "^1.2.5"
+    "line-truncation": "^1.3.9"
   }
 }


### PR DESCRIPTION
bump dependency version for rich text fix https://github.com/DiZhou92/line-truncation/pull/1
This is not a must do bump as ^ compatible version is been used 
