### PR TITLE
Save truncation status in public field

### DIFF
--- a/projects/line-truncation-lib/src/lib/line-truncation.directive.ts
+++ b/projects/line-truncation-lib/src/lib/line-truncation.directive.ts
@@ -62,6 +62,7 @@ export class LineTruncationDirective
   windowResize$ = new Subject<Event>();
   windowListener: Subscription;
   mutationObserver: MutationObserver;
+  isTruncated: boolean;
 
   @HostListener("window:resize", ["$event"])
   handleClick(event: Event) {
@@ -143,7 +144,8 @@ export class LineTruncationDirective
   }
 
   handler(e: boolean) {
-    this.hasTruncated.emit(e);
+    this.isTruncated = e;
+    this.hasTruncated.emit(this.isTruncated);
 
     if (!this.watchChanges) {
       this.observerFlag = false;


### PR DESCRIPTION
This is very useful to get the truncation state directly from the element inside the typescript code, for example:

```typescript
@Component({...})
export class MyComponent implements AfterViewInit {
  @ViewChild(LineTruncationDirective) myTruncableDiv: LineTruncationDirective;

  ngAfterViewInit(): void {
    console.log('Div truncated? ', myTruncableDiv.isTruncated);
  }
}
```