### PR TITLE
Define exportAs property

### DIFF
--- a/projects/line-truncation-lib/src/lib/line-truncation.directive.ts
+++ b/projects/line-truncation-lib/src/lib/line-truncation.directive.ts
@@ -33,7 +33,8 @@ interface Options {
 }
 
 @Directive({
-  selector: "[line-truncation]"
+  selector: "[line-truncation]",
+  exportAs: "lineTruncation"
 })
 export class LineTruncationDirective
   implements AfterViewInit, OnInit, OnDestroy {


### PR DESCRIPTION
This way we can reference the directive directly in the template.

Just like:

```html
<div [line-truncation]="3" #myVar="lineTruncation">...</div>
<div *ngIf="myVar.isTruncated">Toggle if above dive is truncated</div>
```